### PR TITLE
Add LiquidJS configuration for template file resolution

### DIFF
--- a/.eleventy.cjs
+++ b/.eleventy.cjs
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = function(eleventyConfig) {
   // Copy static assets to output (from root directory)
   eleventyConfig.addPassthroughCopy({ "css": "css" });
@@ -19,6 +21,11 @@ module.exports = function(eleventyConfig) {
     },
     templateFormats: ["html", "njk", "md"],
     htmlTemplateEngine: "njk",
-    markdownTemplateEngine: "njk"
+    markdownTemplateEngine: "njk",
+    liquidOptions: {
+      fileLoaderRoot: [path.resolve(__dirname, './src/_includes')],
+      root: [path.resolve(__dirname, './src')],
+      strictFiltering: true
+    }
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "maximelaine-portfolio",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "liquidjs": "^10.25.6"
+      },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
         "terser": "^5.44.0",
@@ -2157,10 +2160,10 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.25.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.0.tgz",
-      "integrity": "sha512-XpO7AiGULTG4xcTlwkcTI5JreFG7b6esLCLp+aUSh7YuQErJZEoUXre9u9rbdb0057pfWG4l0VursvLd5Q/eAw==",
-      "dev": true,
+      "version": "10.25.6",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.6.tgz",
+      "integrity": "sha512-h5ki5HS1PiL9/NmLw3iUcTF1jQswKJd8KLEXNrtSf8XHF0v3c5+d+8llz3N9I5IUdc5rsOuVLb9AVnqvqqscPg==",
+      "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"
       },
@@ -2180,7 +2183,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "@11ty/eleventy": "^3.1.2",
     "terser": "^5.44.0",
     "vite": "^7.2.2"
+  },
+  "dependencies": {
+    "liquidjs": "^10.25.6"
   }
 }


### PR DESCRIPTION
## Summary
This PR adds LiquidJS template engine configuration to the Eleventy setup to enable proper file resolution for Liquid templates.

## Key Changes
- Added `path` module import to `.eleventy.cjs`
- Configured `liquidOptions` in the Eleventy config with:
  - `fileLoaderRoot`: Points to `./src/_includes` for template includes
  - `root`: Points to `./src` for template resolution
  - `strictFiltering`: Enabled for stricter template filtering
- Added `liquidjs` (v10.25.6) as a project dependency

## Implementation Details
The LiquidJS configuration uses `path.resolve()` with `__dirname` to ensure cross-platform compatibility when resolving template directories. This allows Liquid templates to properly locate and include files from the configured include and root directories.

https://claude.ai/code/session_01TyyaUyqBxh6fwYSeJHRPZR